### PR TITLE
summariseClinicalRecords

### DIFF
--- a/R/summariseClinicalRecords.R
+++ b/R/summariseClinicalRecords.R
@@ -407,7 +407,7 @@ addVariables <- function(x, variables) {
   name <- omopgenerics::tableName(x)
 
   newNames <- c(
-    "person_id",
+    "person_id" = "person_id",
     "id" = tableId(name),
     "start_date" = startDate(name),
     "end_date"   = endDate(name),
@@ -474,8 +474,8 @@ addVariables <- function(x, variables) {
               .data$end_date <= .data$obs_end
           ) |>
           dplyr::mutate("in_observation" = 1L) |>
-          dplyr::select("in_observation", "id", "person_id"),
-        by = c("id", "person_id")
+          dplyr::select(any_of(c("in_observation", "id", "person_id"))),
+        by = c("person_id", "id")
       ) |>
       dplyr::distinct()
   }

--- a/R/summariseClinicalRecords.R
+++ b/R/summariseClinicalRecords.R
@@ -474,7 +474,7 @@ addVariables <- function(x, variables) {
               .data$end_date <= .data$obs_end
           ) |>
           dplyr::mutate("in_observation" = 1L) |>
-          dplyr::select(any_of(c("in_observation", "id", "person_id"))),
+          dplyr::select(c("in_observation", "id", "person_id")),
         by = c("person_id", "id")
       ) |>
       dplyr::distinct()

--- a/tests/testthat/test-summariseClinicalRecords.R
+++ b/tests/testthat/test-summariseClinicalRecords.R
@@ -262,4 +262,22 @@ test_that("tableClinicalRecords() works", {
   PatientProfiles::mockDisconnect(cdm = cdm)
 })
 
+test_that("summariseClinicalRecords() works with mock data", {
+  skip_on_cran()
+  # Load mock database ----
+  cdm <- mockOmopSketch()
+
+  # Check all tables work ----
+
+
+  expect_no_error(vo <- summariseClinicalRecords(cdm, "visit_occurrence"))
+
+  expect_no_error(summariseClinicalRecords(cdm, "drug_exposure"))
+  expect_no_error(summariseClinicalRecords(cdm, "procedure_occurrence"))
+
+  expect_warning(summariseClinicalRecords(cdm, "death"))
+
+
+  PatientProfiles::mockDisconnect(cdm = cdm)
+})
 


### PR DESCRIPTION
accounts for cases in which start_date=end_date and person_id = id (such as death table)
Resolves #254 