### PR TITLE
Fix: Ensure database compatibility for boolean aggregations in summariseNumeric2

### DIFF
--- a/R/summarisePerson.R
+++ b/R/summarisePerson.R
@@ -158,17 +158,22 @@ summariseNumeric2 <- function(x, variable, den) {
   x |>
     dplyr::rename(variable_level = !!variable) |>
     dplyr::summarise(
-      count_missing = as.integer(sum(as.numeric(is.na(.data$variable_level)), na.rm = TRUE)),
-      count_0 = as.integer(sum(as.numeric(.data$variable_level == 0), na.rm = TRUE)),
+      # The previous method `sum(as.numeric(is.na(...)))` generates a 
+      # `CAST(boolean AS NUMERIC)` SQL statement, which fails on PostgreSQL.
+      # Using `if_else` generates a portable `CASE WHEN` statement that is
+      # compatible with all database backends.
+      count_missing = sum(if_else(is.na(.data$variable_level), 1L, 0L), na.rm = TRUE),
+      count_0 = sum(if_else(.data$variable_level == 0, 1L, 0L), na.rm = TRUE),
+
       distinct_values = as.integer(dplyr::n_distinct(.data$variable_level))
     ) |>
     dplyr::collect() |>
     dplyr::mutate(
-      count_missing = dplyr::coalesce(.data$count_missing, 0L),
-      count_0 = dplyr::coalesce(.data$count_0, 0L),
-      distinct_values = dplyr::coalesce(.data$distinct_values, 0L),
+      count_missing = dplyr::coalesce(as.integer(.data$count_missing), 0L),
+      count_0 = dplyr::coalesce(as.integer(.data$count_0), 0L),
+      distinct_values = dplyr::coalesce(as.integer(.data$distinct_values), 0L),
       percentage_missing = 100 * as.numeric(.data$count_missing) / .env$den,
-      percentage_0 =  100 * as.numeric(.data$count_0) / .env$den,
+      percentage_0 =  100 * as.numeric(.data$count_0) / .env$den
     )
 }
 


### PR DESCRIPTION
This PR fixes a database compatibility issue in the summariseNumeric2 helper function that causes crashes when running against a PostgreSQL backend. The fix ensures that counting operations on logical conditions are translated into portable SQL.

## Problem
When running summarisePerson(), which calls the internal summariseNumeric2 function, against a PostgreSQL database, the operation fails if there are NA or 0 values in the columns being summarized (e.g., location_id, provider_id).

This is because the code pattern sum(as.numeric(is.na(column))) is translated by dbplyr into a SQL query containing CAST(boolean AS NUMERIC), which is invalid in PostgreSQL. The database returns the following error:
ERROR: cannot cast type boolean to numeric

## Solution
The aggregation logic has been updated to use sum(if_else(condition, 1L, 0L)). This pattern is translated into a standard CASE WHEN SQL statement, which is universally supported across all major database systems and resolves the error.

## How to reproduce this

- Configure a cdm_reference object connected to a PostgreSQL database.
- Ensure the person table contains some records where e.g. ethnicity_id is NA or 0.
- run summarisePerson(cdm). Observe that the command fails with the error mentioned above.