### PR TITLE
Update deprecated function tests for specific DB

### DIFF
--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -1,6 +1,7 @@
 
 test_that("test deprecated functions", {
   skip_on_cran()
+  skip_if(dbToTest != "duckdb-CDMConnector")
 
   cdm <- cdmEunomia()
 
@@ -11,8 +12,6 @@ test_that("test deprecated functions", {
   expect_warning(result <- summariseInObservation(observationPeriod = cdm$observation_period))
   expect_warning(tableInObservation(result = result))
   expect_warning(plotInObservation(result = result))
-
-  skip_if(dbToTest == "local-omopgenerics")
 
   expect_warning(result <- summariseConceptSetCounts(cdm = cdm, conceptSet = list(my_concept = 4112343L)))
   expect_warning(


### PR DESCRIPTION
Added a skip condition to run tests only when dbToTest is 'duckdb-CDMConnector' and removed skip for 'local-omopgenerics'. This ensures deprecated function tests are executed only for the intended database backend.

fix #531 